### PR TITLE
Reduce lookups for BOs, remove temporary data structures and release BOs

### DIFF
--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -64,6 +64,24 @@ static_assert((sizeof(core::ShareableHandle::handle) >= sizeof(uint32_t)) &&
                   (alignof(core::ShareableHandle::handle) >= alignof(uint32_t)),
               "ShareableHandle cannot store a XDNA handle");
 
+// Index where the operand addresses start in a command.
+constexpr uint32_t operand_starting_index = 5;
+
+/// @brief Syncs operand BOs
+static void SyncOperandBOs(uint32_t count, hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload) {
+  // Going through all of the operands in the command and flushing them.
+  const uint32_t num_operands = GetOperandCount(count);
+  for (uint32_t operand_iter = 0; operand_iter < num_operands; operand_iter++) {
+    const uint32_t operand_index = operand_starting_index + 2 * operand_iter;
+    const uint64_t operand_addr = Concat<uint64_t>(cmd_pkt_payload->data[operand_index + 1],
+                                                   cmd_pkt_payload->data[operand_index]);
+    const uint32_t operand_size_starting_index = operand_starting_index + 2 * num_operands;
+    const uint32_t operand_bo_size =
+        cmd_pkt_payload->data[operand_size_starting_index + operand_iter];
+    FlushCpuCache(reinterpret_cast<void*>(operand_addr), 0, operand_bo_size);
+  }
+}
+
 XdnaDriver::XdnaDriver(std::string devnode_name)
     : core::Driver(core::DriverType::XDNA, std::move(devnode_name)) {}
 
@@ -434,17 +452,6 @@ hsa_status_t XdnaDriver::FreeDeviceHeap() {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::SyncBos(const std::vector<uint64_t>& bo_addrs,
-                                 const std::vector<uint32_t>& bo_sizes) {
-  if (bo_addrs.size() != bo_sizes.size()) return HSA_STATUS_ERROR;
-
-  for (size_t i = 0; i < bo_addrs.size(); i++) {
-    FlushCpuCache(reinterpret_cast<void*>(bo_addrs[i]), 0, bo_sizes[i]);
-  }
-
-  return HSA_STATUS_SUCCESS;
-}
-
 hsa_status_t XdnaDriver::ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t hw_ctx_handle) {
   // Submit the cmd
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_EXEC_CMD, exec_cmd) < 0) return HSA_STATUS_ERROR;
@@ -460,51 +467,43 @@ hsa_status_t XdnaDriver::ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& bo_args,
-                                        std::vector<uint32_t>& bo_sizes,
-                                        std::vector<uint64_t>& bo_addrs,
+hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& bo_handles,
                                         hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload) {
-  // This is the index where the operand addresses start in a command
-  const int operand_starting_index = 5;
-
-  // Counting the number of operands in the command payload.
-  uint32_t num_operands = GetOperandCount(count);
-
-  uint64_t instr_addr =
+  const uint64_t instr_addr =
       Concat<uint64_t>(cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX + 1],
                        cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX]);
   auto instr_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(instr_addr));
   if (!instr_handle_info.IsValid()) return HSA_STATUS_ERROR;
 
-  // Keep track of the handles and addresses before we submit the packet
-  bo_args.push_back(instr_handle_info.handle);
-  bo_addrs.push_back(instr_addr);
+  // Keep track of the instruction sequence BO.
+  bo_handles.push_back(instr_handle_info.handle);
 
-  // Adding the instruction sequence size. The packet contains the number of
-  // instructions.
-  uint32_t instr_bo_size =
+  // Flush the instruction sequence. The packet contains the number of instructions.
+  const uint32_t instr_bo_size =
       cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_SIZE_IDX] * INSTR_SIZE_BYTES;
-  bo_sizes.push_back(instr_bo_size);
+  FlushCpuCache(reinterpret_cast<void*>(instr_addr), 0, instr_bo_size);
 
   // Going through all of the operands in the command, keeping track of the
   // addresses and turning the addresses into handles. The starting index of
   // the operands in a command is `operand_starting_index` and the fields
   // are 32-bits we need to iterate over every two
-  for (int operand_iter = 0; operand_iter < num_operands; operand_iter++) {
-    uint32_t operand_index = operand_starting_index + 2 * operand_iter;
-    uint64_t operand_addr = Concat<uint64_t, uint32_t>(cmd_pkt_payload->data[operand_index + 1],
-                                                       cmd_pkt_payload->data[operand_index]);
+  const uint32_t num_operands = GetOperandCount(count);
+  bo_handles.reserve(num_operands);
+  for (uint32_t operand_iter = 0; operand_iter < num_operands; operand_iter++) {
+    const uint32_t operand_index = operand_starting_index + 2 * operand_iter;
+    const uint64_t operand_addr = Concat<uint64_t>(cmd_pkt_payload->data[operand_index + 1],
+                                                   cmd_pkt_payload->data[operand_index]);
     auto operand_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(operand_addr));
     if (!operand_handle_info.IsValid()) return HSA_STATUS_ERROR;
-    bo_args.push_back(operand_handle_info.handle);
-    bo_addrs.push_back(operand_addr);
-  }
 
-  // Going through all of the operands in the command, keeping track of
-  // the sizes of each operand. The size is used to sync the buffer
-  uint32_t operand_size_starting_index = operand_starting_index + 2 * num_operands;
-  for (uint32_t operand_iter = 0; operand_iter < num_operands; operand_iter++) {
-    bo_sizes.push_back(cmd_pkt_payload->data[operand_size_starting_index + operand_iter]);
+    // Keep track of the operand BO.
+    bo_handles.push_back(operand_handle_info.handle);
+
+    // Flush the operand.
+    const uint32_t operand_size_starting_index = operand_starting_index + 2 * num_operands;
+    const uint32_t operand_bo_size =
+        cmd_pkt_payload->data[operand_size_starting_index + operand_iter];
+    FlushCpuCache(reinterpret_cast<void*>(operand_addr), 0, operand_bo_size);
   }
 
   // Transform the instruction sequence address into device address
@@ -536,14 +535,8 @@ hsa_status_t XdnaDriver::CreateCmd(uint32_t size, uint32_t* handle, amdxdna_cmd*
 
 hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
                                         uint32_t num_operands, uint32_t &hw_ctx_handle, uint32_t num_tiles) {
-  // Storing the metadata of the BOs that store the operands and metadata
-  // of the commands we are going to submit
-  std::vector<uint32_t> bo_args;
-  std::vector<uint32_t> bo_sizes;
-  std::vector<uint64_t> bo_addrs;
-  bo_args.reserve(num_operands);
-  bo_sizes.reserve(num_operands);
-  bo_addrs.reserve(num_operands);
+  // Stores instruction and operand BOs.
+  std::vector<uint32_t> bo_handles;
 
   // Storing the commands that we are going to submit and the
   // corresponding metadata
@@ -559,15 +552,15 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   new_cus.reserve(num_pkts);
 
   // Iterating over all the contiguous HSA_AMD_AIE_ERT_CMD_CHAIN packets
-  for (int pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
+  for (uint32_t pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
     // Getting the current command packet
     hsa_amd_aie_ert_packet_t* pkt = first_pkt + pkt_iter;
     hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload =
         reinterpret_cast<hsa_amd_aie_ert_start_kernel_data_t*>(pkt->payload_data);
 
-    // Add the handles for all of the BOs to bo_args as well as rewrite
+    // Add the handles for all of the BOs to bo_handles as well as rewrite
     // the command payload handles to contain the actual virtual addresses
-    hsa_status_t status = RegisterCmdBOs(pkt->count, bo_args, bo_sizes, bo_addrs, cmd_pkt_payload);
+    hsa_status_t status = RegisterCmdBOs(pkt->count, bo_handles, cmd_pkt_payload);
     if (status != HSA_STATUS_SUCCESS) return status;
 
     // Creating a packet that contains the command to execute the kernel
@@ -643,27 +636,30 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     cmd_chain_payload->data[i] = cmd_handles[i];
   }
 
-  // Syncing BOs before we execute the command
-  status = SyncBos(bo_addrs, bo_sizes);
-  if (status != HSA_STATUS_SUCCESS) return status;
-
   // Removing duplicates in the bo container. The driver will report
   // an error if we provide the same BO handle multiple times.
   // This can happen if any of the BOs are the same across jobs
-  std::sort(bo_args.begin(), bo_args.end());
-  bo_args.erase(std::unique(bo_args.begin(), bo_args.end()), bo_args.end());
+  std::sort(bo_handles.begin(), bo_handles.end());
+  bo_handles.erase(std::unique(bo_handles.begin(), bo_handles.end()), bo_handles.end());
 
   // Filling in the fields to execute the command chain
   amdxdna_drm_exec_cmd exec_cmd_0 = {};
   exec_cmd_0.hwctx = hw_ctx_handle;
   exec_cmd_0.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
   exec_cmd_0.cmd_handles = cmd_chain_bo_handle;
-  exec_cmd_0.args = reinterpret_cast<uint64_t>(bo_args.data());
+  exec_cmd_0.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd_0.cmd_count = 1;
-  exec_cmd_0.arg_count = bo_args.size();
+  exec_cmd_0.arg_count = bo_handles.size();
 
   // Executing all commands in the command chain
   ExecCmdAndWait(&exec_cmd_0, hw_ctx_handle);
+
+  for (uint32_t pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
+    hsa_amd_aie_ert_packet_t* pkt = first_pkt + pkt_iter;
+    hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload =
+        reinterpret_cast<hsa_amd_aie_ert_start_kernel_data_t*>(pkt->payload_data);
+    SyncOperandBOs(pkt->count, cmd_pkt_payload);
+  }
 
   // Unmapping and closing the cmd BOs
   drm_gem_close close_bo_args{0};
@@ -677,10 +673,6 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   if (munmap(cmd_chain, cmd_chain_size) != 0) return HSA_STATUS_ERROR;
   close_bo_args.handle = cmd_chain_bo_handle;
   ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-
-  // Syncing BOs after we execute the command
-  status = SyncBos(bo_addrs, bo_sizes);
-  if (status != HSA_STATUS_SUCCESS) return status;
 
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -516,7 +516,8 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
 hsa_status_t XdnaDriver::CreateCmd(uint32_t size, uint32_t* handle, amdxdna_cmd** cmd) {
   // Creating the command
   amdxdna_drm_create_bo create_cmd_bo = {};
-  create_cmd_bo.type = AMDXDNA_BO_CMD, create_cmd_bo.size = size;
+  create_cmd_bo.type = AMDXDNA_BO_CMD;
+  create_cmd_bo.size = size;
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_cmd_bo) < 0) return HSA_STATUS_ERROR;
 
   amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -238,8 +238,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     *mem = mapped_mem;
   }
 
-  vmem_handle_mappings.emplace(create_bo_args.handle, mapped_mem);
-  vmem_addr_mappings.emplace(mapped_mem, BOHandleInfo{create_bo_args.handle, size});
+  vmem_addr_mappings.emplace(mapped_mem, BOHandleInfo{mapped_mem, create_bo_args.handle, size});
 
   return HSA_STATUS_SUCCESS;
 }
@@ -256,7 +255,6 @@ hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
     return HSA_STATUS_ERROR;
   }
 
-  vmem_handle_mappings.erase(handle);
   vmem_addr_mappings.erase(it);
 
   return HSA_STATUS_SUCCESS;
@@ -524,7 +522,7 @@ hsa_status_t XdnaDriver::CreateCmd(uint32_t size, uint32_t* handle, amdxdna_cmd*
 
   amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};
   cmd_bo_get_bo_info.handle = create_cmd_bo.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info)) return HSA_STATUS_ERROR;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) return HSA_STATUS_ERROR;
 
   *cmd = static_cast<amdxdna_cmd*>(mmap(nullptr, create_cmd_bo.size, PROT_READ | PROT_WRITE,
                                         MAP_SHARED, fd_, cmd_bo_get_bo_info.map_offset));
@@ -557,7 +555,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   cmds.reserve(num_pkts);
 
   // The new CUs that we need to register
-  std::vector<uint32_t> new_cus;
+  std::vector<BOHandleInfo> new_cus;
   new_cus.reserve(num_pkts);
 
   // Iterating over all the contiguous HSA_AMD_AIE_ERT_CMD_CHAIN packets
@@ -601,7 +599,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
       // position where the new CU will be
       cu_mask = 1 << handle_cu_mappings.size();
       handle_cu_mappings[cu_bo] = cu_mask;
-      new_cus.push_back(cu_bo);
+      new_cus.push_back(cu_bo_info);
     }
     else {
       cu_mask = cu_mask_iter->second;
@@ -718,47 +716,27 @@ XdnaDriver::BOHandleInfo XdnaDriver::FindBOHandleInfo(void* mem) const {
 }
 
 // Creates a new hardware context with the correct CUs
-hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(
-    uint32_t &hw_ctx_handle,
-    std::vector<uint32_t> new_cus,
-    uint32_t num_tiles) {
+hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle,
+                                           const std::vector<XdnaDriver::BOHandleInfo>& new_cus,
+                                           uint32_t num_tiles) {
+  const size_t config_cu_param_size =
+      sizeof(amdxdna_hwctx_param_config_cu) + new_cus.size() * sizeof(amdxdna_cu_config);
 
-  size_t config_cu_param_size(sizeof(amdxdna_hwctx_param_config_cu) +
-                              (new_cus.size() + cached_cu_bos.size())  *
-                                  sizeof(amdxdna_cu_config));
-
-  amdxdna_hwctx_param_config_cu* xdna_config_cu_param =
+  auto* xdna_config_cu_param =
       static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
   if (xdna_config_cu_param == nullptr) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
   MAKE_SCOPE_GUARD([xdna_config_cu_param] { free(xdna_config_cu_param); });
 
-  xdna_config_cu_param->num_cus = cached_cu_bos.size() + new_cus.size();
+  xdna_config_cu_param->num_cus = new_cus.size();
 
-  for (size_t i = 0; i < cached_cu_bos.size(); i++) {
-    xdna_config_cu_param->cu_configs[i].cu_bo = cached_cu_bos[i];
+  for (size_t i = 0; i < new_cus.size(); i++) {
+    xdna_config_cu_param->cu_configs[i].cu_bo = new_cus[i].handle;
     xdna_config_cu_param->cu_configs[i].cu_func = DEFAULT_CU_FUNC;
 
     // Flush the CU out of the cache
-    auto cu_addr = vmem_handle_mappings.find(cached_cu_bos[i]);
-    if (cu_addr == vmem_handle_mappings.end())
-      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-    size_t size = core::Runtime::runtime_singleton_->GetSize(cu_addr->second);
-    FlushCpuCache(cu_addr->second, 0, size);
-  }
-
-  for (size_t i = cached_cu_bos.size(); i < new_cus.size() + cached_cu_bos.size(); i++) {
-    xdna_config_cu_param->cu_configs[i].cu_bo = new_cus[i - cached_cu_bos.size()];
-    xdna_config_cu_param->cu_configs[i].cu_func = DEFAULT_CU_FUNC;
-
-    // Flush the CU out of the cache
-    auto cu_addr = vmem_handle_mappings.find(new_cus[i - cached_cu_bos.size()]);
-    if (cu_addr == vmem_handle_mappings.end())
-      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-    size_t size = core::Runtime::runtime_singleton_->GetSize(cu_addr->second);
-
-    FlushCpuCache(cu_addr->second, 0, size);
+    FlushCpuCache(new_cus[i].vaddr, 0, new_cus[i].size);
   }
 
   // Destroy the hardware context

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -263,7 +263,9 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
 hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
   auto it = vmem_addr_mappings.find(mem);
-  if (it == vmem_addr_mappings.end()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  if (it == vmem_addr_mappings.end()) {
+    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  }
 
   auto handle = it->second.handle;
 
@@ -327,9 +329,9 @@ hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
-  if (ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0)
+  if (ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0) {
     return HSA_STATUS_ERROR;
-
+  }
   handle.handle = import_params.handle;
   return HSA_STATUS_SUCCESS;
 }
@@ -341,34 +343,35 @@ hsa_status_t XdnaDriver::Map(core::ShareableHandle handle, void *mem,
   drm_prime_handle params = {};
   params.handle = handle.handle;
   params.fd = -1;
-  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0)
+  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
     return HSA_STATUS_ERROR;
+  }
 
   // Change permissions.
   void *mapped_ptr = mmap(mem, size, PermissionsToMmapFlags(perms),
                           MAP_FIXED | MAP_SHARED, params.fd, offset);
-  if (mapped_ptr == MAP_FAILED)
-    return HSA_STATUS_ERROR;
+  if (mapped_ptr == MAP_FAILED) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
 
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::Unmap(core::ShareableHandle handle, void *mem,
                                size_t offset, size_t size) {
-  if (munmap(mem, size) != 0)
+  if (munmap(mem, size) != 0) {
     return HSA_STATUS_ERROR;
-
+  }
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::ReleaseShareableHandle(core::ShareableHandle &handle) {
   drm_gem_close close_params = {};
   close_params.handle = handle.handle;
-  if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0)
+  if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0) {
     return HSA_STATUS_ERROR;
-
+  }
   handle = {};
-
   return HSA_STATUS_SUCCESS;
 }
 
@@ -454,7 +457,9 @@ hsa_status_t XdnaDriver::FreeDeviceHeap() {
 
 hsa_status_t XdnaDriver::ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t hw_ctx_handle) {
   // Submit the cmd
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_EXEC_CMD, exec_cmd) < 0) return HSA_STATUS_ERROR;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_EXEC_CMD, exec_cmd) < 0) {
+    return HSA_STATUS_ERROR;
+  }
 
   // Waiting for command to finish
   amdxdna_drm_wait_cmd wait_cmd = {};
@@ -462,7 +467,9 @@ hsa_status_t XdnaDriver::ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t
   wait_cmd.timeout = DEFAULT_TIMEOUT_VAL;
   wait_cmd.seq = exec_cmd->seq;
 
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) return HSA_STATUS_ERROR;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
+    return HSA_STATUS_ERROR;
+  }
 
   return HSA_STATUS_SUCCESS;
 }
@@ -513,23 +520,33 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::CreateCmd(uint32_t size, uint32_t* handle, amdxdna_cmd** cmd) {
-  // Creating the command
+hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandleInfo& bo_info) {
   amdxdna_drm_create_bo create_cmd_bo = {};
   create_cmd_bo.type = AMDXDNA_BO_CMD;
   create_cmd_bo.size = size;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_cmd_bo) < 0) return HSA_STATUS_ERROR;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_cmd_bo) < 0) {
+    return HSA_STATUS_ERROR;
+  }
 
   amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};
   cmd_bo_get_bo_info.handle = create_cmd_bo.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) return HSA_STATUS_ERROR;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) {
+    drm_gem_close close_bo_args = {};
+    close_bo_args.handle = create_cmd_bo.handle;
+    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+    return HSA_STATUS_ERROR;
+  }
 
-  *cmd = static_cast<amdxdna_cmd*>(mmap(nullptr, create_cmd_bo.size, PROT_READ | PROT_WRITE,
-                                        MAP_SHARED, fd_, cmd_bo_get_bo_info.map_offset));
+  void* mem = static_cast<amdxdna_cmd*>(mmap(nullptr, create_cmd_bo.size, PROT_READ | PROT_WRITE,
+                                             MAP_SHARED, fd_, cmd_bo_get_bo_info.map_offset));
+  if (mem == MAP_FAILED) {
+    drm_gem_close close_bo_args = {};
+    close_bo_args.handle = create_cmd_bo.handle;
+    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+    return HSA_STATUS_ERROR;
+  }
 
-  if (cmd == MAP_FAILED) return HSA_STATUS_ERROR;
-
-  *handle = create_cmd_bo.handle;
+  bo_info = BOHandleInfo{mem, create_cmd_bo.handle, size};
 
   return HSA_STATUS_SUCCESS;
 }
@@ -557,14 +574,18 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     // Add the handles for all of the BOs to bo_handles as well as rewrite
     // the command payload handles to contain the actual virtual addresses
     hsa_status_t status = RegisterCmdBOs(pkt->count, bo_handles, cmd_pkt_payload);
-    if (status != HSA_STATUS_SUCCESS) return status;
+    if (status != HSA_STATUS_SUCCESS) {
+      return status;
+    }
 
     // Creating a packet that contains the command to execute the kernel
-    uint32_t cmd_bo_handle = 0;
-    amdxdna_cmd* cmd = nullptr;
-    uint32_t cmd_size = sizeof(amdxdna_cmd) + pkt->count * sizeof(uint32_t);
-    status = CreateCmd(cmd_size, &cmd_bo_handle, &cmd);
-    if (status != HSA_STATUS_SUCCESS) return status;
+    const uint32_t cmd_size = sizeof(amdxdna_cmd) + pkt->count * sizeof(uint32_t);
+    BOHandleInfo cmd_bo_info;
+    status = CreateCmdBO(cmd_size, cmd_bo_info);
+    if (status != HSA_STATUS_SUCCESS) {
+      return status;
+    }
+    auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_info.vaddr);
 
     // Filling in the fields of the command
     cmd->state = pkt->state;
@@ -598,7 +619,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     memcpy((cmd->data + 1), cmd_pkt_payload->data, 4 * pkt->count);
 
     // Keeping track of the command
-    command_bo.emplace_back(cmd, cmd_bo_handle, cmd_size);
+    command_bo.push_back(cmd_bo_info);
   }
 
   // If we have CUs that are not cached we will add them to
@@ -609,11 +630,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   }
 
   // Creating a packet that contains the command chain
-  uint32_t cmd_chain_bo_handle = 0;
-  amdxdna_cmd* cmd_chain = nullptr;
-  uint32_t cmd_chain_size = (command_bo.size() + 1) * sizeof(uint32_t);
-  hsa_status_t status = CreateCmd(cmd_chain_size, &cmd_chain_bo_handle, &cmd_chain);
-  if (status != HSA_STATUS_SUCCESS) return status;
+  const uint32_t cmd_chain_size = (command_bo.size() + 1) * sizeof(uint32_t);
+  BOHandleInfo cmd_chain_bo;
+  hsa_status_t status = CreateCmdBO(cmd_chain_size, cmd_chain_bo);
+  if (status != HSA_STATUS_SUCCESS) {
+    return status;
+  }
+  auto* cmd_chain = static_cast<amdxdna_cmd*>(cmd_chain_bo.vaddr);
 
   // Writing information to the command buffer
   amdxdna_cmd_chain* cmd_chain_payload = reinterpret_cast<amdxdna_cmd_chain*>(cmd_chain->data);
@@ -640,7 +663,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   amdxdna_drm_exec_cmd exec_cmd_0 = {};
   exec_cmd_0.hwctx = hw_ctx_handle;
   exec_cmd_0.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
-  exec_cmd_0.cmd_handles = cmd_chain_bo_handle;
+  exec_cmd_0.cmd_handles = cmd_chain_bo.handle;
   exec_cmd_0.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd_0.cmd_count = 1;
   exec_cmd_0.arg_count = bo_handles.size();
@@ -666,7 +689,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Unmapping and closing the cmd_chain BO
   if (munmap(cmd_chain, cmd_chain_size) != 0) return HSA_STATUS_ERROR;
   drm_gem_close close_bo_args = {};
-  close_bo_args.handle = cmd_chain_bo_handle;
+  close_bo_args.handle = cmd_chain_bo.handle;
   ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
 
   return HSA_STATUS_SUCCESS;

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -402,30 +402,32 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
+  dev_heap_handle.handle = create_bo_args.handle;
+
   // Unmap memory and close the BO in case of error.
-  MAKE_NAMED_SCOPE_GUARD(dev_heap_guard, [&] {
-    munmap(dev_heap_parent, dev_heap_align * 2 - 1);
-    dev_heap_parent = nullptr;
+  MAKE_NAMED_SCOPE_GUARD(dev_heap_handle_guard, [&] {
+    munmap(dev_heap_handle.vaddr, dev_heap_handle.size);
     drm_gem_close close_bo_args = {};
-    close_bo_args.handle = create_bo_args.handle;
+    close_bo_args.handle = dev_heap_handle.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+    dev_heap_handle = BOHandle{};
   });
 
   amdxdna_drm_get_bo_info get_bo_info_args = {};
-  get_bo_info_args.handle = create_bo_args.handle;
+  get_bo_info_args.handle = dev_heap_handle.handle;
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
     return HSA_STATUS_ERROR;
   }
 
-  dev_heap_parent = mmap(0, dev_heap_align * 2 - 1, PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-  if (dev_heap_parent == MAP_FAILED) {
-    dev_heap_parent = nullptr;
+  const size_t size = dev_heap_align * 2 - 1;
+  dev_heap_handle.vaddr = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (dev_heap_handle.vaddr == MAP_FAILED) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
+  dev_heap_handle.size = size;
 
   void* addr_aligned = reinterpret_cast<void*>(
-      AlignUp(reinterpret_cast<uintptr_t>(dev_heap_parent), dev_heap_align));
+      AlignUp(reinterpret_cast<uintptr_t>(dev_heap_handle.vaddr), dev_heap_align));
 
   dev_heap_aligned =
       mmap(addr_aligned, dev_heap_size, PROT_READ | PROT_WRITE,
@@ -435,28 +437,32 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  dev_heap_guard.Dismiss();
+  dev_heap_handle_guard.Dismiss();
 
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::FreeDeviceHeap() {
-  // TODO need to close the dev_heap_parent BO
-  if (dev_heap_parent) {
-    if (munmap(dev_heap_parent, dev_heap_align * 2 - 1) != 0) {
-      return HSA_STATUS_ERROR;
-    }
-    dev_heap_parent = nullptr;
-  }
+  hsa_status_t status = HSA_STATUS_SUCCESS;
 
   if (dev_heap_aligned) {
     if (munmap(dev_heap_aligned, dev_heap_size) != 0) {
-      return HSA_STATUS_ERROR;
+      status = HSA_STATUS_ERROR;
     }
     dev_heap_aligned = nullptr;
   }
 
-  return HSA_STATUS_SUCCESS;
+  if (dev_heap_handle.IsValid()) {
+    if (munmap(dev_heap_handle.vaddr, dev_heap_handle.size) != 0) {
+      status = HSA_STATUS_ERROR;
+    }
+    drm_gem_close close_bo_args = {};
+    close_bo_args.handle = dev_heap_handle.handle;
+    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+    dev_heap_handle = BOHandle{};
+  }
+
+  return status;
 }
 
 hsa_status_t XdnaDriver::ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t hw_ctx_handle) {

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -538,14 +538,9 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Stores instruction and operand BOs.
   std::vector<uint32_t> bo_handles;
 
-  // Storing the commands that we are going to submit and the
-  // corresponding metadata
-  std::vector<uint32_t> cmd_handles;
-  std::vector<uint32_t> cmd_sizes;
-  std::vector<amdxdna_cmd*> cmds;
-  cmd_handles.reserve(num_pkts);
-  cmd_sizes.reserve(num_pkts);
-  cmds.reserve(num_pkts);
+  // Stores commands that we are going to submit and the corresponding metadata.
+  std::vector<BOHandleInfo> command_bo;
+  command_bo.reserve(num_pkts);
 
   // The new CUs that we need to register
   std::vector<BOHandleInfo> new_cus;
@@ -601,10 +596,8 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     cmd->data[0] = cu_mask;
     memcpy((cmd->data + 1), cmd_pkt_payload->data, 4 * pkt->count);
 
-    // Keeping track of the handle
-    cmd_handles.push_back(cmd_bo_handle);
-    cmds.push_back(cmd);
-    cmd_sizes.push_back(cmd_size);
+    // Keeping track of the command
+    command_bo.emplace_back(cmd, cmd_bo_handle, cmd_size);
   }
 
   // If we have CUs that are not cached we will add them to
@@ -617,7 +610,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Creating a packet that contains the command chain
   uint32_t cmd_chain_bo_handle = 0;
   amdxdna_cmd* cmd_chain = nullptr;
-  int cmd_chain_size = (cmd_handles.size() + 1) * sizeof(uint32_t);
+  uint32_t cmd_chain_size = (command_bo.size() + 1) * sizeof(uint32_t);
   hsa_status_t status = CreateCmd(cmd_chain_size, &cmd_chain_bo_handle, &cmd_chain);
   if (status != HSA_STATUS_SUCCESS) return status;
 
@@ -627,13 +620,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Creating a command chain
   cmd_chain->state = HSA_AMD_AIE_ERT_STATE_NEW;
   cmd_chain->extra_cu_masks = 0;
-  cmd_chain->count = sizeof(amdxdna_cmd_chain) + cmd_handles.size() * sizeof(uint64_t);
+  cmd_chain->count = sizeof(amdxdna_cmd_chain) + command_bo.size() * sizeof(uint64_t);
   cmd_chain->opcode = HSA_AMD_AIE_ERT_CMD_CHAIN;
-  cmd_chain_payload->command_count = cmd_handles.size();
+  cmd_chain_payload->command_count = command_bo.size();
   cmd_chain_payload->submit_index = 0;
   cmd_chain_payload->error_index = 0;
-  for (int i = 0; i < cmd_handles.size(); i++) {
-    cmd_chain_payload->data[i] = cmd_handles[i];
+  for (size_t i = 0; i < command_bo.size(); i++) {
+    cmd_chain_payload->data[i] = command_bo[i].handle;
   }
 
   // Removing duplicates in the bo container. The driver will report
@@ -662,15 +655,16 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   }
 
   // Unmapping and closing the cmd BOs
-  drm_gem_close close_bo_args{0};
-  for (int i = 0; i < cmd_handles.size(); i++) {
-    if (munmap(cmds[i], cmd_sizes[i]) != 0) return HSA_STATUS_ERROR;
-    close_bo_args.handle = cmd_handles[i];
+  for (auto& bo_info : command_bo) {
+    if (munmap(bo_info.vaddr, bo_info.size) != 0) return HSA_STATUS_ERROR;
+    drm_gem_close close_bo_args = {};
+    close_bo_args.handle = bo_info.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
   }
 
   // Unmapping and closing the cmd_chain BO
   if (munmap(cmd_chain, cmd_chain_size) != 0) return HSA_STATUS_ERROR;
+  drm_gem_close close_bo_args = {};
   close_bo_args.handle = cmd_chain_bo_handle;
   ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
 

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -221,7 +221,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  BOHandleInfo bo_handle;
+  BOHandle bo_handle;
   bo_handle.handle = create_bo_args.handle;
   bo_handle.size = size;
 
@@ -483,13 +483,13 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
   const uint64_t instr_addr =
       Concat<uint64_t>(cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX + 1],
                        cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX]);
-  auto instr_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(instr_addr));
-  if (!instr_handle_info.IsValid()) {
+  auto instr_bo_handle = FindBOHandle(reinterpret_cast<void*>(instr_addr));
+  if (!instr_bo_handle.IsValid()) {
     return HSA_STATUS_ERROR;
   }
 
   // Keep track of the instruction sequence BO.
-  bo_handles.push_back(instr_handle_info.handle);
+  bo_handles.push_back(instr_bo_handle.handle);
 
   // Flush the instruction sequence. The packet contains the number of instructions.
   const uint32_t instr_bo_size =
@@ -506,13 +506,13 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
     const uint32_t operand_index = operand_starting_index + 2 * operand_iter;
     const uint64_t operand_addr = Concat<uint64_t>(cmd_pkt_payload->data[operand_index + 1],
                                                    cmd_pkt_payload->data[operand_index]);
-    auto operand_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(operand_addr));
-    if (!operand_handle_info.IsValid()) {
+    auto operand_bo_handle = FindBOHandle(reinterpret_cast<void*>(operand_addr));
+    if (!operand_bo_handle.IsValid()) {
       return HSA_STATUS_ERROR;
     }
 
     // Keep track of the operand BO.
-    bo_handles.push_back(operand_handle_info.handle);
+    bo_handles.push_back(operand_bo_handle.handle);
 
     // Flush the operand.
     const uint32_t operand_size_starting_index = operand_starting_index + 2 * num_operands;
@@ -528,7 +528,7 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandleInfo& bo_info) {
+hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
   amdxdna_drm_create_bo create_cmd_bo = {};
   create_cmd_bo.type = AMDXDNA_BO_CMD;
   create_cmd_bo.size = size;
@@ -537,7 +537,7 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandleInfo& bo_info) {
   }
 
   // Close the BO in case of error.
-  MAKE_NAMED_SCOPE_GUARD(bo_guard, [&] {
+  MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] {
     drm_gem_close close_bo_args = {};
     close_bo_args.handle = create_cmd_bo.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
@@ -555,9 +555,9 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandleInfo& bo_info) {
     return HSA_STATUS_ERROR;
   }
 
-  bo_info = BOHandleInfo{mem, create_cmd_bo.handle, size};
+  cmd_bo_handle = BOHandle{mem, create_cmd_bo.handle, size};
 
-  bo_guard.Dismiss();
+  cmd_bo_handle_guard.Dismiss();
 
   return HSA_STATUS_SUCCESS;
 }
@@ -568,11 +568,11 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   std::vector<uint32_t> bo_handles;
 
   // Stores commands that we are going to submit and the corresponding metadata.
-  std::vector<BOHandleInfo> command_bo;
-  command_bo.reserve(num_pkts);
+  std::vector<BOHandle> command_bo_handles;
+  command_bo_handles.reserve(num_pkts);
   // Unmap and close the command BOs in case of an error.
-  MAKE_NAMED_SCOPE_GUARD(command_bo_guard, [&] {
-    for (auto& bo_info : command_bo) {
+  MAKE_NAMED_SCOPE_GUARD(command_bo_handles_guard, [&] {
+    for (auto& bo_info : command_bo_handles) {
       munmap(bo_info.vaddr, bo_info.size);
       drm_gem_close close_bo_args = {};
       close_bo_args.handle = bo_info.handle;
@@ -581,7 +581,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   });
 
   // The new CUs that we need to register
-  std::vector<BOHandleInfo> new_cus;
+  std::vector<BOHandle> new_cus;
   new_cus.reserve(num_pkts);
 
   // Iterating over all the contiguous HSA_AMD_AIE_ERT_CMD_CHAIN packets
@@ -600,20 +600,20 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
 
     // Creating a packet that contains the command to execute the kernel
     const uint32_t cmd_size = sizeof(amdxdna_cmd) + pkt->count * sizeof(uint32_t);
-    BOHandleInfo cmd_bo_info;
-    status = CreateCmdBO(cmd_size, cmd_bo_info);
+    BOHandle cmd_bo_handle;
+    status = CreateCmdBO(cmd_size, cmd_bo_handle);
     if (status != HSA_STATUS_SUCCESS) {
       return status;
     }
     // Unmap and close the command BO in case of an error.
-    MAKE_NAMED_SCOPE_GUARD(cmd_bo_guard, [&] {
-      munmap(cmd_bo_info.vaddr, cmd_bo_info.size);
+    MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] {
+      munmap(cmd_bo_handle.vaddr, cmd_bo_handle.size);
       drm_gem_close close_bo_args = {};
-      close_bo_args.handle = cmd_bo_info.handle;
+      close_bo_args.handle = cmd_bo_handle.handle;
       ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
     });
 
-    auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_info.vaddr);
+    auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_handle.vaddr);
 
     // Filling in the fields of the command
     cmd->state = pkt->state;
@@ -625,9 +625,9 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     cmd->opcode = pkt->opcode;
 
     // Finding BO handle associated with the CU
-    auto cu_bo_info = FindBOHandleInfo(cmd_pkt_payload->pdi_addr);
-    if (!cu_bo_info.IsValid()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-    uint32_t cu_bo = cu_bo_info.handle;
+    auto cu_bo_handle = FindBOHandle(cmd_pkt_payload->pdi_addr);
+    if (!cu_bo_handle.IsValid()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    uint32_t cu_bo = cu_bo_handle.handle;
 
     // Determining if the CU is cached
     auto cu_mask_iter = handle_cu_mappings.find(cu_bo);
@@ -637,7 +637,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
       // position where the new CU will be
       cu_mask = 1 << handle_cu_mappings.size();
       handle_cu_mappings[cu_bo] = cu_mask;
-      new_cus.push_back(cu_bo_info);
+      new_cus.push_back(cu_bo_handle);
     }
     else {
       cu_mask = cu_mask_iter->second;
@@ -647,8 +647,8 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     memcpy((cmd->data + 1), cmd_pkt_payload->data, 4 * pkt->count);
 
     // Keeping track of the command
-    command_bo.push_back(cmd_bo_info);
-    cmd_bo_guard.Dismiss();
+    command_bo_handles.push_back(cmd_bo_handle);
+    cmd_bo_handle_guard.Dismiss();
   }
 
   // If we have CUs that are not cached we will add them to
@@ -661,21 +661,21 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   }
 
   // Creating a packet that contains the command chain
-  const uint32_t cmd_chain_size = (command_bo.size() + 1) * sizeof(uint32_t);
-  BOHandleInfo cmd_chain_bo;
-  hsa_status_t status = CreateCmdBO(cmd_chain_size, cmd_chain_bo);
+  const uint32_t cmd_chain_size = (command_bo_handles.size() + 1) * sizeof(uint32_t);
+  BOHandle cmd_chain_bo_handle;
+  hsa_status_t status = CreateCmdBO(cmd_chain_size, cmd_chain_bo_handle);
   if (status != HSA_STATUS_SUCCESS) {
     return status;
   }
   // Unmap and close the command chain BO in case of an error.
-  MAKE_NAMED_SCOPE_GUARD(cmd_chain_bo_guard, [&] {
-    munmap(cmd_chain_bo.vaddr, cmd_chain_bo.size);
+  MAKE_NAMED_SCOPE_GUARD(cmd_chain_bo_handle_guard, [&] {
+    munmap(cmd_chain_bo_handle.vaddr, cmd_chain_bo_handle.size);
     drm_gem_close close_bo_args = {};
-    close_bo_args.handle = cmd_chain_bo.handle;
+    close_bo_args.handle = cmd_chain_bo_handle.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
   });
 
-  auto* cmd_chain = static_cast<amdxdna_cmd*>(cmd_chain_bo.vaddr);
+  auto* cmd_chain = static_cast<amdxdna_cmd*>(cmd_chain_bo_handle.vaddr);
 
   // Writing information to the command buffer
   amdxdna_cmd_chain* cmd_chain_payload = reinterpret_cast<amdxdna_cmd_chain*>(cmd_chain->data);
@@ -683,13 +683,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Creating a command chain
   cmd_chain->state = HSA_AMD_AIE_ERT_STATE_NEW;
   cmd_chain->extra_cu_masks = 0;
-  cmd_chain->count = sizeof(amdxdna_cmd_chain) + command_bo.size() * sizeof(uint64_t);
+  cmd_chain->count = sizeof(amdxdna_cmd_chain) + command_bo_handles.size() * sizeof(uint64_t);
   cmd_chain->opcode = HSA_AMD_AIE_ERT_CMD_CHAIN;
-  cmd_chain_payload->command_count = command_bo.size();
+  cmd_chain_payload->command_count = command_bo_handles.size();
   cmd_chain_payload->submit_index = 0;
   cmd_chain_payload->error_index = 0;
-  for (size_t i = 0; i < command_bo.size(); i++) {
-    cmd_chain_payload->data[i] = command_bo[i].handle;
+  for (size_t i = 0; i < command_bo_handles.size(); i++) {
+    cmd_chain_payload->data[i] = command_bo_handles[i].handle;
   }
 
   // Removing duplicates in the bo container. The driver will report
@@ -702,7 +702,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   amdxdna_drm_exec_cmd exec_cmd_0 = {};
   exec_cmd_0.hwctx = hw_ctx_handle;
   exec_cmd_0.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
-  exec_cmd_0.cmd_handles = cmd_chain_bo.handle;
+  exec_cmd_0.cmd_handles = cmd_chain_bo_handle.handle;
   exec_cmd_0.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd_0.cmd_count = 1;
   exec_cmd_0.arg_count = bo_handles.size();
@@ -720,33 +720,33 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   status = HSA_STATUS_SUCCESS;
 
   // Unmapping and closing the cmd BOs
-  command_bo_guard.Dismiss();
-  for (auto& bo_info : command_bo) {
-    if (munmap(bo_info.vaddr, bo_info.size) != 0) {
+  command_bo_handles_guard.Dismiss();
+  for (auto& command_bo_handle : command_bo_handles) {
+    if (munmap(command_bo_handle.vaddr, command_bo_handle.size) != 0) {
       status = HSA_STATUS_ERROR;
     }
     drm_gem_close close_bo_args = {};
-    close_bo_args.handle = bo_info.handle;
+    close_bo_args.handle = command_bo_handle.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
   }
 
   // Unmapping and closing the cmd_chain BO
-  cmd_chain_bo_guard.Dismiss();
+  cmd_chain_bo_handle_guard.Dismiss();
   if (munmap(cmd_chain, cmd_chain_size) != 0) {
     status = HSA_STATUS_ERROR;
   }
   drm_gem_close close_bo_args = {};
-  close_bo_args.handle = cmd_chain_bo.handle;
+  close_bo_args.handle = cmd_chain_bo_handle.handle;
   ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
 
   return status;
 }
 
-XdnaDriver::BOHandleInfo XdnaDriver::FindBOHandleInfo(void* mem) const {
+XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
   auto it = vmem_addr_mappings.lower_bound(mem);
   if (it == vmem_addr_mappings.cend()) {
     // Exact address not found or is larger than the largest address.
-    return BOHandleInfo{};
+    return BOHandle{};
   }
 
   if (it->first == mem) {
@@ -756,7 +756,7 @@ XdnaDriver::BOHandleInfo XdnaDriver::FindBOHandleInfo(void* mem) const {
 
   if (it == vmem_addr_mappings.cbegin()) {
     // Address is smaller than the smallest registered address.
-    return BOHandleInfo{};
+    return BOHandle{};
   }
 
   // Go back one element, since lower_bound returns an iterator to the element that is equal or
@@ -766,7 +766,7 @@ XdnaDriver::BOHandleInfo XdnaDriver::FindBOHandleInfo(void* mem) const {
   assert(it->first < mem);
   if (mem >= (static_cast<char*>(it->first) + it->second.size)) {
     // Address is not from this allocation.
-    return BOHandleInfo{};
+    return BOHandle{};
   }
 
   return it->second;
@@ -774,7 +774,7 @@ XdnaDriver::BOHandleInfo XdnaDriver::FindBOHandleInfo(void* mem) const {
 
 // Creates a new hardware context with the correct CUs
 hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle,
-                                           const std::vector<XdnaDriver::BOHandleInfo>& new_cus,
+                                           const std::vector<BOHandle>& new_cus,
                                            uint32_t num_tiles) {
   const size_t config_cu_param_size =
       sizeof(amdxdna_hwctx_param_config_cu) + new_cus.size() * sizeof(amdxdna_cu_config);

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -221,42 +221,46 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
+  BOHandleInfo bo_handle;
+  bo_handle.handle = create_bo_args.handle;
+  bo_handle.size = size;
+
+  // Close the BO in case of error.
+  MAKE_NAMED_SCOPE_GUARD(bo_guard, [&] {
+    munmap(bo_handle.vaddr, bo_handle.size);
+    drm_gem_close close_bo_args = {};
+    close_bo_args.handle = bo_handle.handle;
+    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+  });
+
   amdxdna_drm_get_bo_info get_bo_info_args = {};
   get_bo_info_args.handle = create_bo_args.handle;
-
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
-    // Close the BO in the case we can't get info about it.
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = create_bo_args.handle;
-    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
     return HSA_STATUS_ERROR;
   }
 
   /// TODO: For now we always map the memory and keep a mapping from handles
   /// to VA memory addresses. Once we can support the separate VMEM call to
   /// map handles we can fix this.
-  void* mapped_mem = nullptr;
   if (use_bo_shmem) {
-    mapped_mem = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_,
-                      get_bo_info_args.map_offset);
-    if (mapped_mem == MAP_FAILED) {
-      // Close the BO in the case when a mapping fails and we got a BO handle.
-      drm_gem_close close_bo_args = {};
-      close_bo_args.handle = create_bo_args.handle;
-      ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+    bo_handle.vaddr =
+        mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, get_bo_info_args.map_offset);
+    if (bo_handle.vaddr == MAP_FAILED) {
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
   } else {
-    mapped_mem = reinterpret_cast<void *>(get_bo_info_args.vaddr);
+    bo_handle.vaddr = reinterpret_cast<void*>(get_bo_info_args.vaddr);
   }
 
   if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
     *mem = reinterpret_cast<void *>(create_bo_args.handle);
   } else {
-    *mem = mapped_mem;
+    *mem = bo_handle.vaddr;
   }
 
-  vmem_addr_mappings.emplace(mapped_mem, BOHandleInfo{mapped_mem, create_bo_args.handle, size});
+  vmem_addr_mappings.emplace(bo_handle.vaddr, bo_handle);
+
+  bo_guard.Dismiss();
 
   return HSA_STATUS_SUCCESS;
 }
@@ -398,57 +402,57 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  amdxdna_drm_get_bo_info get_bo_info_args = {};
-  get_bo_info_args.handle = create_bo_args.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
-    // Close the BO in the case we can't get info about it.
+  // Unmap memory and close the BO in case of error.
+  MAKE_NAMED_SCOPE_GUARD(dev_heap_guard, [&] {
+    munmap(dev_heap_parent, dev_heap_align * 2 - 1);
+    dev_heap_parent = nullptr;
     drm_gem_close close_bo_args = {};
     close_bo_args.handle = create_bo_args.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+  });
+
+  amdxdna_drm_get_bo_info get_bo_info_args = {};
+  get_bo_info_args.handle = create_bo_args.handle;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
     return HSA_STATUS_ERROR;
   }
 
   dev_heap_parent = mmap(0, dev_heap_align * 2 - 1, PROT_READ | PROT_WRITE,
                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-
   if (dev_heap_parent == MAP_FAILED) {
-    // Close the BO in the case when a mapping fails and we got a BO handle.
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = create_bo_args.handle;
-    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
     dev_heap_parent = nullptr;
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  void *addr_aligned(reinterpret_cast<void *>(
-      AlignUp(reinterpret_cast<uintptr_t>(dev_heap_parent), dev_heap_align)));
+  void* addr_aligned = reinterpret_cast<void*>(
+      AlignUp(reinterpret_cast<uintptr_t>(dev_heap_parent), dev_heap_align));
 
   dev_heap_aligned =
       mmap(addr_aligned, dev_heap_size, PROT_READ | PROT_WRITE,
            MAP_SHARED | MAP_FIXED, fd_, get_bo_info_args.map_offset);
-
   if (dev_heap_aligned == MAP_FAILED) {
-    // Close the BO in the case when a mapping fails and we got a BO handle.
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = create_bo_args.handle;
-    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-    // Unmap the dev_heap_parent.
     dev_heap_aligned = nullptr;
-    FreeDeviceHeap();
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
+
+  dev_heap_guard.Dismiss();
 
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::FreeDeviceHeap() {
+  // TODO need to close the dev_heap_parent BO
   if (dev_heap_parent) {
-    if (munmap(dev_heap_parent, dev_heap_align * 2 - 1) != 0) return HSA_STATUS_ERROR;
+    if (munmap(dev_heap_parent, dev_heap_align * 2 - 1) != 0) {
+      return HSA_STATUS_ERROR;
+    }
     dev_heap_parent = nullptr;
   }
 
   if (dev_heap_aligned) {
-    if (munmap(dev_heap_aligned, dev_heap_size) != 0) return HSA_STATUS_ERROR;
+    if (munmap(dev_heap_aligned, dev_heap_size) != 0) {
+      return HSA_STATUS_ERROR;
+    }
     dev_heap_aligned = nullptr;
   }
 
@@ -480,7 +484,9 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
       Concat<uint64_t>(cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX + 1],
                        cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX]);
   auto instr_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(instr_addr));
-  if (!instr_handle_info.IsValid()) return HSA_STATUS_ERROR;
+  if (!instr_handle_info.IsValid()) {
+    return HSA_STATUS_ERROR;
+  }
 
   // Keep track of the instruction sequence BO.
   bo_handles.push_back(instr_handle_info.handle);
@@ -501,7 +507,9 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
     const uint64_t operand_addr = Concat<uint64_t>(cmd_pkt_payload->data[operand_index + 1],
                                                    cmd_pkt_payload->data[operand_index]);
     auto operand_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(operand_addr));
-    if (!operand_handle_info.IsValid()) return HSA_STATUS_ERROR;
+    if (!operand_handle_info.IsValid()) {
+      return HSA_STATUS_ERROR;
+    }
 
     // Keep track of the operand BO.
     bo_handles.push_back(operand_handle_info.handle);
@@ -528,25 +536,28 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandleInfo& bo_info) {
     return HSA_STATUS_ERROR;
   }
 
-  amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};
-  cmd_bo_get_bo_info.handle = create_cmd_bo.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) {
+  // Close the BO in case of error.
+  MAKE_NAMED_SCOPE_GUARD(bo_guard, [&] {
     drm_gem_close close_bo_args = {};
     close_bo_args.handle = create_cmd_bo.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+  });
+
+  amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};
+  cmd_bo_get_bo_info.handle = create_cmd_bo.handle;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) {
     return HSA_STATUS_ERROR;
   }
 
   void* mem = static_cast<amdxdna_cmd*>(mmap(nullptr, create_cmd_bo.size, PROT_READ | PROT_WRITE,
                                              MAP_SHARED, fd_, cmd_bo_get_bo_info.map_offset));
   if (mem == MAP_FAILED) {
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = create_cmd_bo.handle;
-    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
     return HSA_STATUS_ERROR;
   }
 
   bo_info = BOHandleInfo{mem, create_cmd_bo.handle, size};
+
+  bo_guard.Dismiss();
 
   return HSA_STATUS_SUCCESS;
 }
@@ -559,6 +570,15 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Stores commands that we are going to submit and the corresponding metadata.
   std::vector<BOHandleInfo> command_bo;
   command_bo.reserve(num_pkts);
+  // Unmap and close the command BOs in case of an error.
+  MAKE_NAMED_SCOPE_GUARD(command_bo_guard, [&] {
+    for (auto& bo_info : command_bo) {
+      munmap(bo_info.vaddr, bo_info.size);
+      drm_gem_close close_bo_args = {};
+      close_bo_args.handle = bo_info.handle;
+      ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+    }
+  });
 
   // The new CUs that we need to register
   std::vector<BOHandleInfo> new_cus;
@@ -585,6 +605,14 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     if (status != HSA_STATUS_SUCCESS) {
       return status;
     }
+    // Unmap and close the command BO in case of an error.
+    MAKE_NAMED_SCOPE_GUARD(cmd_bo_guard, [&] {
+      munmap(cmd_bo_info.vaddr, cmd_bo_info.size);
+      drm_gem_close close_bo_args = {};
+      close_bo_args.handle = cmd_bo_info.handle;
+      ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+    });
+
     auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_info.vaddr);
 
     // Filling in the fields of the command
@@ -620,13 +648,16 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
 
     // Keeping track of the command
     command_bo.push_back(cmd_bo_info);
+    cmd_bo_guard.Dismiss();
   }
 
   // If we have CUs that are not cached we will add them to
   // the hardware context
   if (!new_cus.empty()) {
     hsa_status_t status = ConfigHwCtxNewCUs(hw_ctx_handle, new_cus, num_tiles);
-    if (status != HSA_STATUS_SUCCESS) return status;
+    if (status != HSA_STATUS_SUCCESS) {
+      return status;
+    }
   }
 
   // Creating a packet that contains the command chain
@@ -636,6 +667,14 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   if (status != HSA_STATUS_SUCCESS) {
     return status;
   }
+  // Unmap and close the command chain BO in case of an error.
+  MAKE_NAMED_SCOPE_GUARD(cmd_chain_bo_guard, [&] {
+    munmap(cmd_chain_bo.vaddr, cmd_chain_bo.size);
+    drm_gem_close close_bo_args = {};
+    close_bo_args.handle = cmd_chain_bo.handle;
+    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
+  });
+
   auto* cmd_chain = static_cast<amdxdna_cmd*>(cmd_chain_bo.vaddr);
 
   // Writing information to the command buffer
@@ -678,21 +717,29 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     SyncOperandBOs(pkt->count, cmd_pkt_payload);
   }
 
+  status = HSA_STATUS_SUCCESS;
+
   // Unmapping and closing the cmd BOs
+  command_bo_guard.Dismiss();
   for (auto& bo_info : command_bo) {
-    if (munmap(bo_info.vaddr, bo_info.size) != 0) return HSA_STATUS_ERROR;
+    if (munmap(bo_info.vaddr, bo_info.size) != 0) {
+      status = HSA_STATUS_ERROR;
+    }
     drm_gem_close close_bo_args = {};
     close_bo_args.handle = bo_info.handle;
     ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
   }
 
   // Unmapping and closing the cmd_chain BO
-  if (munmap(cmd_chain, cmd_chain_size) != 0) return HSA_STATUS_ERROR;
+  cmd_chain_bo_guard.Dismiss();
+  if (munmap(cmd_chain, cmd_chain_size) != 0) {
+    status = HSA_STATUS_ERROR;
+  }
   drm_gem_close close_bo_args = {};
   close_bo_args.handle = cmd_chain_bo.handle;
   ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
 
-  return HSA_STATUS_SUCCESS;
+  return status;
 }
 
 XdnaDriver::BOHandleInfo XdnaDriver::FindBOHandleInfo(void* mem) const {

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -300,7 +300,7 @@ hsa_status_t XdnaDriver::DestroyQueue(core::Queue &queue) const {
     return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
-  auto &aie_queue = static_cast<AieAqlQueue &>(queue);
+  auto& aie_queue = static_cast<AieAqlQueue&>(queue);
   if (aie_queue.GetHwCtxHandle() != AMDXDNA_INVALID_BO_HANDLE) {
     amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
     destroy_hwctx_args.handle = aie_queue.GetHwCtxHandle();

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -534,7 +534,7 @@ hsa_status_t XdnaDriver::CreateCmd(uint32_t size, uint32_t* handle, amdxdna_cmd*
 }
 
 hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
-                                        uint32_t num_operands, uint32_t &hw_ctx_handle, uint32_t num_tiles) {
+                                        uint32_t& hw_ctx_handle, uint32_t num_tiles) {
   // Stores instruction and operand BOs.
   std::vector<uint32_t> bo_handles;
 

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -289,20 +289,8 @@ hsa_status_t XdnaDriver::CreateQueue(core::Queue &queue) const {
     return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
-  auto &aie_queue(static_cast<AieAqlQueue &>(queue));
-  auto &aie_agent(aie_queue.GetAgent());
-
-  // Currently we do not leverage QoS information.
-  amdxdna_qos_info qos_info = {};
-  amdxdna_drm_create_hwctx create_hwctx_args = {};
-  create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
-  create_hwctx_args.max_opc = 0x800;
-  create_hwctx_args.num_tiles = aie_agent.GetNumCores();
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-  }
-
-  aie_queue.SetHwCtxHandle(create_hwctx_args.handle);
+  auto& aie_queue = static_cast<AieAqlQueue&>(queue);
+  aie_queue.SetHwCtxHandle(AMDXDNA_INVALID_BO_HANDLE);
 
   return HSA_STATUS_SUCCESS;
 }
@@ -312,11 +300,13 @@ hsa_status_t XdnaDriver::DestroyQueue(core::Queue &queue) const {
     return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
-  auto &aie_queue(static_cast<AieAqlQueue &>(queue));
-  amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
-  destroy_hwctx_args.handle = aie_queue.GetHwCtxHandle();
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
-    return HSA_STATUS_ERROR;
+  auto &aie_queue = static_cast<AieAqlQueue &>(queue);
+  if (aie_queue.GetHwCtxHandle() != AMDXDNA_INVALID_BO_HANDLE) {
+    amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
+    destroy_hwctx_args.handle = aie_queue.GetHwCtxHandle();
+    if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
+      return HSA_STATUS_ERROR;
+    }
   }
 
   return HSA_STATUS_SUCCESS;
@@ -802,15 +792,17 @@ hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle,
     FlushCpuCache(new_cus[i].vaddr, 0, new_cus[i].size);
   }
 
-  // Destroy the hardware context
-  // Note: we can do this because we have forced synchronization between
-  // command chains. If we move to a more asynchronous model, we will need to
-  // figure out how hardware context destruction works while applications
-  // are running
-  amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
-  destroy_hwctx_args.handle = hw_ctx_handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
-    return HSA_STATUS_ERROR;
+  if (hw_ctx_handle != AMDXDNA_INVALID_BO_HANDLE) {
+    // Destroy the hardware context
+    // Note: we can do this because we have forced synchronization between
+    // command chains. If we move to a more asynchronous model, we will need to
+    // figure out how hardware context destruction works while applications
+    // are running
+    amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
+    destroy_hwctx_args.handle = hw_ctx_handle;
+    if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
+      return HSA_STATUS_ERROR;
+    }
   }
 
   // Create the new hardware context

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -239,7 +239,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
   }
 
   vmem_handle_mappings.emplace(create_bo_args.handle, mapped_mem);
-  vmem_addr_mappings.emplace(mapped_mem, create_bo_args.handle);
+  vmem_addr_mappings.emplace(mapped_mem, BOHandleInfo{create_bo_args.handle, size});
 
   return HSA_STATUS_SUCCESS;
 }
@@ -248,7 +248,7 @@ hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
   auto it = vmem_addr_mappings.find(mem);
   if (it == vmem_addr_mappings.end()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
-  auto handle = it->second;
+  auto handle = it->second.handle;
 
   drm_gem_close close_args = {};
   close_args.handle = handle;
@@ -472,14 +472,14 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
   // Counting the number of operands in the command payload.
   uint32_t num_operands = GetOperandCount(count);
 
-  uint64_t instr_addr = Concat<uint64_t, uint32_t>(
-      cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX + 1],
-      cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX]);
-  auto instr_handle = FindBOHandle(reinterpret_cast<void*>(instr_addr));
-  if (instr_handle == AMDXDNA_INVALID_BO_HANDLE) return HSA_STATUS_ERROR;
+  uint64_t instr_addr =
+      Concat<uint64_t>(cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX + 1],
+                       cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX]);
+  auto instr_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(instr_addr));
+  if (!instr_handle_info.IsValid()) return HSA_STATUS_ERROR;
 
   // Keep track of the handles and addresses before we submit the packet
-  bo_args.push_back(instr_handle);
+  bo_args.push_back(instr_handle_info.handle);
   bo_addrs.push_back(instr_addr);
 
   // Adding the instruction sequence size. The packet contains the number of
@@ -496,9 +496,9 @@ hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& b
     uint32_t operand_index = operand_starting_index + 2 * operand_iter;
     uint64_t operand_addr = Concat<uint64_t, uint32_t>(cmd_pkt_payload->data[operand_index + 1],
                                                        cmd_pkt_payload->data[operand_index]);
-    auto operand_handle = FindBOHandle(reinterpret_cast<void*>(operand_addr));
-    if (operand_handle == AMDXDNA_INVALID_BO_HANDLE) return HSA_STATUS_ERROR;
-    bo_args.push_back(operand_handle);
+    auto operand_handle_info = FindBOHandleInfo(reinterpret_cast<void*>(operand_addr));
+    if (!operand_handle_info.IsValid()) return HSA_STATUS_ERROR;
+    bo_args.push_back(operand_handle_info.handle);
     bo_addrs.push_back(operand_addr);
   }
 
@@ -589,8 +589,9 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     cmd->opcode = pkt->opcode;
 
     // Finding BO handle associated with the CU
-    uint32_t cu_bo = FindBOHandle(cmd_pkt_payload->pdi_addr);
-    if (cu_bo == AMDXDNA_INVALID_BO_HANDLE) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    auto cu_bo_info = FindBOHandleInfo(cmd_pkt_payload->pdi_addr);
+    if (!cu_bo_info.IsValid()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    uint32_t cu_bo = cu_bo_info.handle;
 
     // Determining if the CU is cached
     auto cu_mask_iter = handle_cu_mappings.find(cu_bo);
@@ -686,11 +687,11 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   return HSA_STATUS_SUCCESS;
 }
 
-uint32_t XdnaDriver::FindBOHandle(void* mem) {
+XdnaDriver::BOHandleInfo XdnaDriver::FindBOHandleInfo(void* mem) const {
   auto it = vmem_addr_mappings.lower_bound(mem);
   if (it == vmem_addr_mappings.cend()) {
     // Exact address not found or is larger than the largest address.
-    return AMDXDNA_INVALID_BO_HANDLE;
+    return BOHandleInfo{};
   }
 
   if (it->first == mem) {
@@ -700,12 +701,18 @@ uint32_t XdnaDriver::FindBOHandle(void* mem) {
 
   if (it == vmem_addr_mappings.cbegin()) {
     // Address is smaller than the smallest registered address.
-    return AMDXDNA_INVALID_BO_HANDLE;
+    return BOHandleInfo{};
   }
 
   // Go back one element, since lower_bound returns an iterator to the element that is equal or
   // greater.
   --it;
+
+  assert(it->first < mem);
+  if (mem >= (static_cast<char*>(it->first) + it->second.size)) {
+    // Address is not from this allocation.
+    return BOHandleInfo{};
+  }
 
   return it->second;
 }

--- a/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -133,10 +133,9 @@ private:
   void *ring_buf_ = nullptr;
 
   /// @brief Called when the doorbell is rung to iterate over
-  /// all packets and submit them. Submissions is done by
-  // calling into the XdnaDriver.
-  hsa_status_t SubmitCmd(XdnaDriver& driver, void* queue_base, uint64_t read_dispatch_id,
-                         uint64_t write_dispatch_id);
+  /// all packets and submit them. Submission is done by
+  /// calling into the XdnaDriver.
+  hsa_status_t SubmitCmd(void* queue_base, uint64_t read_dispatch_id, uint64_t write_dispatch_id);
 
   /// @brief Handle for an application context on the AIE device.
   ///

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -132,13 +132,16 @@ inline uint32_t GetOperandCount(uint32_t arg_count) {
 
 class XdnaDriver final : public core::Driver {
   /// @brief BO handle information.
-  struct BOHandleInfo {
+  struct BOHandle {
+    /// Mapped address.
     void* vaddr = nullptr;
+    /// Handle returned by xdna.
     uint32_t handle = AMDXDNA_INVALID_BO_HANDLE;
+    /// Size in bytes.
     size_t size = 0;
 
-    constexpr BOHandleInfo() = default;
-    constexpr BOHandleInfo(void* vaddr, uint32_t handle, size_t size)
+    constexpr BOHandle() = default;
+    constexpr BOHandle(void* vaddr, uint32_t handle, size_t size)
         : vaddr{vaddr}, handle{handle}, size{size} {}
     constexpr bool IsValid() const { return handle != AMDXDNA_INVALID_BO_HANDLE; }
   };
@@ -191,10 +194,10 @@ public:
 
  private:
   /// @brief Finds the BO associated with the address.
-  BOHandleInfo FindBOHandleInfo(void* mem) const;
+  BOHandle FindBOHandle(void* mem) const;
 
   // @brief Creates a new hardware context with the correct CUs
-  hsa_status_t ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle, const std::vector<BOHandleInfo>& new_cus,
+  hsa_status_t ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle, const std::vector<BOHandle>& new_cus,
                                  uint32_t num_tiles);
 
   hsa_status_t QueryDriverVersion();
@@ -209,7 +212,7 @@ public:
   ///
   /// @param size size of memory to allocate
   /// @param bo_info allocated BO
-  hsa_status_t CreateCmdBO(uint32_t size, BOHandleInfo& bo_info);
+  hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info);
 
   /// @brief Adds all BOs in a command packet payload to a vector
   ///         and replaces the handles with a virtual address
@@ -231,7 +234,7 @@ public:
   /// object to track handle allocations. Using the VMEM API for mapping XDNA
   /// driver handles requires a bit more refactoring. So rely on the XDNA driver
   /// to manage some of this for now.
-  std::map<void*, BOHandleInfo> vmem_addr_mappings;
+  std::map<void*, BOHandle> vmem_addr_mappings;
 
   /// @brief Storing cached CUs that have already been added to the hardware context.
   /// This maps the CU BO to the cu_mask in the hardware context

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -133,11 +133,13 @@ inline uint32_t GetOperandCount(uint32_t arg_count) {
 class XdnaDriver final : public core::Driver {
   /// @brief BO handle information.
   struct BOHandleInfo {
+    void* vaddr = nullptr;
     uint32_t handle = AMDXDNA_INVALID_BO_HANDLE;
-    size_t size = {};
+    size_t size = 0;
 
     constexpr BOHandleInfo() = default;
-    constexpr BOHandleInfo(uint32_t handle, size_t size) : handle{handle}, size{size} {}
+    constexpr BOHandleInfo(void* vaddr, uint32_t handle, size_t size)
+        : vaddr{vaddr}, handle{handle}, size{size} {}
     constexpr bool IsValid() const { return handle != AMDXDNA_INVALID_BO_HANDLE; }
   };
 
@@ -192,10 +194,8 @@ public:
   BOHandleInfo FindBOHandleInfo(void* mem) const;
 
   // @brief Creates a new hardware context with the correct CUs
-  hsa_status_t ConfigHwCtxNewCUs(
-      uint32_t &hw_ctx_handle,
-      std::vector<uint32_t> new_cus,
-      uint32_t num_tiles);
+  hsa_status_t ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle, const std::vector<BOHandleInfo>& new_cus,
+                                 uint32_t num_tiles);
 
   hsa_status_t QueryDriverVersion();
 
@@ -239,13 +239,11 @@ public:
   /// object to track handle allocations. Using the VMEM API for mapping XDNA
   /// driver handles requires a bit more refactoring. So rely on the XDNA driver
   /// to manage some of this for now.
-  std::unordered_map<uint32_t, void*> vmem_handle_mappings;
   std::map<void*, BOHandleInfo> vmem_addr_mappings;
 
   /// @brief Storing cached CUs that have already been added to the hardware context.
   /// This maps the CU BO to the cu_mask in the hardware context
   std::unordered_map<uint32_t, uint32_t> handle_cu_mappings;
-  std::vector<uint32_t> cached_cu_bos;
 
   /// @brief Virtual address range allocated for the device heap.
   ///

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -131,6 +131,16 @@ inline uint32_t GetOperandCount(uint32_t arg_count) {
 }
 
 class XdnaDriver final : public core::Driver {
+  /// @brief BO handle information.
+  struct BOHandleInfo {
+    uint32_t handle = AMDXDNA_INVALID_BO_HANDLE;
+    size_t size = {};
+
+    constexpr BOHandleInfo() = default;
+    constexpr BOHandleInfo(uint32_t handle, size_t size) : handle{handle}, size{size} {}
+    constexpr bool IsValid() const { return handle != AMDXDNA_INVALID_BO_HANDLE; }
+  };
+
 public:
   XdnaDriver(std::string devnode_name);
 
@@ -179,13 +189,16 @@ public:
 
  private:
   /// @brief Finds the BO associated with the address.
-  uint32_t FindBOHandle(void* mem);
+  BOHandleInfo FindBOHandleInfo(void* mem) const;
 
   // @brief Creates a new hardware context with the correct CUs
-  hsa_status_t ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle, std::vector<uint32_t> new_cus,
-                                 uint32_t num_tiles);
+  hsa_status_t ConfigHwCtxNewCUs(
+      uint32_t &hw_ctx_handle,
+      std::vector<uint32_t> new_cus,
+      uint32_t num_tiles);
 
   hsa_status_t QueryDriverVersion();
+
   /// @brief Allocate device accesible heap space.
   ///
   /// Allocate and map a buffer object (BO) that the AIE device can access.
@@ -227,7 +240,7 @@ public:
   /// driver handles requires a bit more refactoring. So rely on the XDNA driver
   /// to manage some of this for now.
   std::unordered_map<uint32_t, void*> vmem_handle_mappings;
-  std::map<void*, uint32_t> vmem_addr_mappings;
+  std::map<void*, BOHandleInfo> vmem_addr_mappings;
 
   /// @brief Storing cached CUs that have already been added to the hardware context.
   /// This maps the CU BO to the cu_mask in the hardware context

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -205,13 +205,11 @@ public:
   hsa_status_t InitDeviceHeap();
   hsa_status_t FreeDeviceHeap();
 
-  /// @brief Creates a command BO and returns a pointer to the memory and
-  //          the corresponding handle
+  /// @brief Creates a command BO and returns it to @p bo_info.
   ///
   /// @param size size of memory to allocate
-  /// @param handle A pointer to the BO handle
-  /// @param cmd A pointer to the buffer
-  hsa_status_t CreateCmd(uint32_t size, uint32_t* handle, amdxdna_cmd** cmd);
+  /// @param bo_info allocated BO
+  hsa_status_t CreateCmdBO(uint32_t size, BOHandleInfo& bo_info);
 
   /// @brief Adds all BOs in a command packet payload to a vector
   ///         and replaces the handles with a virtual address

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -187,7 +187,7 @@ public:
 
   // @brief Submits num_pkts packets in a command chain to the XDNA driver
   hsa_status_t SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
-                              uint32_t num_operands, uint32_t &hw_ctx_handle, uint32_t num_tiles);
+                              uint32_t& hw_ctx_handle, uint32_t num_tiles);
 
  private:
   /// @brief Finds the BO associated with the address.

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -217,16 +217,10 @@ public:
   ///         and replaces the handles with a virtual address
   ///
   /// @param count Number of entries in the command
-  /// @param bo_args A pointer to a vector that contains all bo handles
+  /// @param bo_handles vector that contains all bo handles
   /// @param cmd_pkt_payload A pointer to the payload of the command
-  hsa_status_t RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& bo_args,
-                              std::vector<uint32_t>& bo_sizes, std::vector<uint64_t>& bo_addrs,
+  hsa_status_t RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& bo_handles,
                               hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload);
-
-  /// @brief Syncs all BOs referenced in bo_args
-  ///
-  /// @param bo_args vector containing handles of BOs to sync
-  hsa_status_t SyncBos(const std::vector<uint64_t>& bo_args, const std::vector<uint32_t>& bo_sizes);
 
   /// @brief Executes a command and waits for its completion
   ///

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -245,7 +245,7 @@ public:
   /// Allocate a large enough space so we can carve out the device heap in
   /// this range and ensure it is aligned to 64MB. Currently, npu1 supports
   /// 64MB device heap and it must be aligned to 64MB.
-  void *dev_heap_parent = nullptr;
+  BOHandle dev_heap_handle;
 
   /// @brief The aligned device heap.
   void *dev_heap_aligned = nullptr;

--- a/runtime/hsa-runtime/core/inc/runtime.h
+++ b/runtime/hsa-runtime/core/inc/runtime.h
@@ -495,10 +495,6 @@ class Runtime {
 
   std::vector<std::unique_ptr<Driver>>& AgentDrivers() { return agent_drivers_; }
 
-  /// @brief Get the size of an allocation associated with the provided address
-  /// If no allocation is found, zero is returned
-  size_t GetSize(void* address);
-
  protected:
   static void AsyncEventsLoop(void*);
   static void AsyncIPCSockServerConnLoop(void*);

--- a/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -218,20 +218,18 @@ hsa_status_t AieAqlQueue::SubmitCmd(XdnaDriver& driver, void* queue_base, uint64
         // Iterating over future packets and seeing how many contiguous HSA_AMD_AIE_ERT_START_CU
         // packets there are. All can be combined into a single chain.
         int num_cont_start_cu_pkts = 1;
-        int num_operands = 0;
         for (int peak_pkt_id = cur_id + 1; peak_pkt_id < write_dispatch_id; peak_pkt_id++) {
           hsa_amd_aie_ert_packet_t* peak_pkt =
               static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + peak_pkt_id;
           if (peak_pkt->opcode != HSA_AMD_AIE_ERT_START_CU) {
             break;
           }
-          num_operands += GetOperandCount(peak_pkt->count);
           num_cont_start_cu_pkts++;
         }
 
         // Call into the driver to submit from cur_id to write_dispatch_id
-        if (driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, num_operands, hw_ctx_handle_, GetAgent().GetNumCores()) !=
-            HSA_STATUS_SUCCESS)
+        if (driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, hw_ctx_handle_,
+                                  GetAgent().GetNumCores()) != HSA_STATUS_SUCCESS)
           return HSA_STATUS_ERROR;
 
         // Submitting the command chain might involve create a new hardware context, if so

--- a/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -227,14 +227,14 @@ hsa_status_t AieAqlQueue::SubmitCmd(void* queue_base, uint64_t read_dispatch_id,
           num_cont_start_cu_pkts++;
         }
 
-        // Call into the driver to submit from cur_id to write_dispatch_id
-        if (driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, hw_ctx_handle_,
-                                  GetAgent().GetNumCores()) != HSA_STATUS_SUCCESS)
-          return HSA_STATUS_ERROR;
+        // Call into the driver to submit from cur_id to write_dispatch_id.
+        // Submitting the command chain might involve create a new hardware context.
+        hsa_status_t status = driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, hw_ctx_handle_,
+                                                    GetAgent().GetNumCores());
+        if (status != HSA_STATUS_SUCCESS) {
+          return status;
+        }
 
-        // Submitting the command chain might involve create a new hardware context, if so
-        // we need to update the handle accordingly
-        SetHwCtxHandle(hw_ctx_handle_);
         cur_id += num_cont_start_cu_pkts;
         break;
       }

--- a/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -196,13 +196,13 @@ uint64_t AieAqlQueue::AddWriteIndexAcqRel(uint64_t value) {
 }
 
 void AieAqlQueue::StoreRelaxed(hsa_signal_value_t value) {
-  auto& driver = static_cast<XdnaDriver&>(agent_.driver());
-  SubmitCmd(driver, amd_queue_.hsa_queue.base_address, amd_queue_.read_dispatch_id,
+  SubmitCmd(amd_queue_.hsa_queue.base_address, amd_queue_.read_dispatch_id,
             amd_queue_.write_dispatch_id);
 }
 
-hsa_status_t AieAqlQueue::SubmitCmd(XdnaDriver& driver, void* queue_base, uint64_t read_dispatch_id,
+hsa_status_t AieAqlQueue::SubmitCmd(void* queue_base, uint64_t read_dispatch_id,
                                     uint64_t write_dispatch_id) {
+  auto& driver = static_cast<XdnaDriver&>(agent_.driver());
   uint64_t cur_id = read_dispatch_id;
   while (cur_id < write_dispatch_id) {
     hsa_amd_aie_ert_packet_t* pkt = static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + cur_id;

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -312,12 +312,6 @@ hsa_status_t Runtime::IterateAgent(hsa_status_t (*callback)(hsa_agent_t agent,
   return HSA_STATUS_SUCCESS;
 }
 
-/// @brief Get the size of an allocation associated with the provided address
-/// if no allocation is found, 0 is returned
-size_t Runtime::GetSize(void *address) {
-  return allocation_map_[address].size;
-}
-
 hsa_status_t Runtime::AllocateMemory(const MemoryRegion* region, size_t size,
                                      MemoryRegion::AllocateFlags alloc_flags,
                                      void** address, int agent_node_id) {


### PR DESCRIPTION
This PR
1. Removes extra maps and temporary vectors.
2. Reduces the number of lookups in existing vectors.
3. Releases BOs in case of error and upon shutdown.

The `BOHandle` is getting closer to be a proper Runtime::MemoryHandle (from VMem).

The cached CUs will be addressed in a separate PR.