### PR TITLE
Per-hardware context PDI caching

### DIFF
--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -575,11 +575,11 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   std::vector<uint32_t> bo_handles;
 
   // Stores commands that we are going to submit and the corresponding metadata.
-  std::vector<BOHandle> command_bo_handles;
-  command_bo_handles.reserve(num_pkts);
+  std::vector<BOHandle> cmd_bo_handles;
+  cmd_bo_handles.reserve(num_pkts);
   // Unmap and close the command BOs in case of an error.
-  MAKE_NAMED_SCOPE_GUARD(command_bo_handles_guard, [&] {
-    for (auto& bo_info : command_bo_handles) {
+  MAKE_NAMED_SCOPE_GUARD(cmd_bo_handles_guard, [&] {
+    for (auto& bo_info : cmd_bo_handles) {
       munmap(bo_info.vaddr, bo_info.size);
       drm_gem_close close_bo_args = {};
       close_bo_args.handle = bo_info.handle;
@@ -587,9 +587,10 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     }
   });
 
-  // The new CUs that we need to register
-  std::vector<BOHandle> new_cus;
-  new_cus.reserve(num_pkts);
+  // PDI cache. If the cache is updated, a new hardware context will be created for the queue.
+  auto pdi_cache_it = hw_ctx_pdi_cache_map.find(aie_queue.GetHwCtxHandle());
+  auto pdi_cache = (pdi_cache_it != hw_ctx_pdi_cache_map.end()) ? pdi_cache_it->second : PDICache{};
+  bool reconfigure_queue = false;
 
   // Iterating over all the contiguous HSA_AMD_AIE_ERT_CMD_CHAIN packets
   for (uint32_t pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
@@ -631,44 +632,48 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     cmd->count = pkt->count + CMD_COUNT_SIZE_INCREASE;
     cmd->opcode = pkt->opcode;
 
-    // Finding BO handle associated with the CU
-    auto cu_bo_handle = FindBOHandle(cmd_pkt_payload->pdi_addr);
-    if (!cu_bo_handle.IsValid()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-    uint32_t cu_bo = cu_bo_handle.handle;
+    // Find if the PDI is cached in the queues PDI cache. If even one PDI is not found, the hardware
+    // context will need to be reconfigured and the cache updated.
+    auto pdi_bo_handle = FindBOHandle(cmd_pkt_payload->pdi_addr);
+    if (!pdi_bo_handle.IsValid()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
-    // Determining if the CU is cached
-    auto cu_mask_iter = handle_cu_mappings.find(cu_bo);
-    uint32_t cu_mask = 0;
-    if (cu_mask_iter == handle_cu_mappings.end()) {
-      // CU mask is one hot encoded, putting the
-      // position where the new CU will be
-      cu_mask = 1 << handle_cu_mappings.size();
-      handle_cu_mappings[cu_bo] = cu_mask;
-      new_cus.push_back(cu_bo_handle);
-    }
-    else {
-      cu_mask = cu_mask_iter->second;
+    // Determining if the PDI is cached
+    auto cached_pdi_index = pdi_cache.GetIndex(pdi_bo_handle.handle);
+    if (cached_pdi_index == PDICache::NotFound) {
+      // PDI does not exist in the cache.
+      status = pdi_cache.SetNext(pdi_bo_handle, cached_pdi_index);
+      if (status != HSA_STATUS_SUCCESS) {
+        return status;
+      }
+      reconfigure_queue = true;
     }
 
-    cmd->data[0] = cu_mask;
+    cmd->data[0] = 0x1 << static_cast<uint32_t>(cached_pdi_index);
     memcpy((cmd->data + 1), cmd_pkt_payload->data, 4 * pkt->count);
 
     // Keeping track of the command
-    command_bo_handles.push_back(cmd_bo_handle);
+    cmd_bo_handles.push_back(cmd_bo_handle);
     cmd_bo_handle_guard.Dismiss();
   }
 
-  // If we have CUs that are not cached we will add them to
-  // the hardware context
-  if (!new_cus.empty()) {
-    hsa_status_t status = ConfigHwCtxNewCUs(new_cus, aie_queue);
+  // If there were PDIs that were not cached, the hardware context needs to be reconfigured.
+  // The cache map will be update with the new hardware context.
+  if (reconfigure_queue) {
+    if (pdi_cache_it != hw_ctx_pdi_cache_map.end()) {
+      hw_ctx_pdi_cache_map.erase(pdi_cache_it);
+    }
+
+    hsa_status_t status = ConfigHwCtx(pdi_cache, aie_queue);
     if (status != HSA_STATUS_SUCCESS) {
       return status;
     }
+
+    // Update cache mapping.
+    hw_ctx_pdi_cache_map.emplace(aie_queue.GetHwCtxHandle(), pdi_cache);
   }
 
   // Creating a packet that contains the command chain
-  const uint32_t cmd_chain_size = (command_bo_handles.size() + 1) * sizeof(uint32_t);
+  const uint32_t cmd_chain_size = (cmd_bo_handles.size() + 1) * sizeof(uint32_t);
   BOHandle cmd_chain_bo_handle;
   hsa_status_t status = CreateCmdBO(cmd_chain_size, cmd_chain_bo_handle);
   if (status != HSA_STATUS_SUCCESS) {
@@ -690,13 +695,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Creating a command chain
   cmd_chain->state = HSA_AMD_AIE_ERT_STATE_NEW;
   cmd_chain->extra_cu_masks = 0;
-  cmd_chain->count = sizeof(amdxdna_cmd_chain) + command_bo_handles.size() * sizeof(uint64_t);
+  cmd_chain->count = sizeof(amdxdna_cmd_chain) + cmd_bo_handles.size() * sizeof(uint64_t);
   cmd_chain->opcode = HSA_AMD_AIE_ERT_CMD_CHAIN;
-  cmd_chain_payload->command_count = command_bo_handles.size();
+  cmd_chain_payload->command_count = cmd_bo_handles.size();
   cmd_chain_payload->submit_index = 0;
   cmd_chain_payload->error_index = 0;
-  for (size_t i = 0; i < command_bo_handles.size(); i++) {
-    cmd_chain_payload->data[i] = command_bo_handles[i].handle;
+  for (size_t i = 0; i < cmd_bo_handles.size(); i++) {
+    cmd_chain_payload->data[i] = cmd_bo_handles[i].handle;
   }
 
   // Removing duplicates in the bo container. The driver will report
@@ -721,8 +726,8 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   status = HSA_STATUS_SUCCESS;
 
   // Unmapping and closing the cmd BOs
-  command_bo_handles_guard.Dismiss();
-  for (auto& command_bo_handle : command_bo_handles) {
+  cmd_bo_handles_guard.Dismiss();
+  for (auto& command_bo_handle : cmd_bo_handles) {
     if (munmap(command_bo_handle.vaddr, command_bo_handle.size) != 0) {
       status = HSA_STATUS_ERROR;
     }
@@ -773,11 +778,9 @@ XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
   return it->second;
 }
 
-// Creates a new hardware context with the correct CUs
-hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(const std::vector<BOHandle>& new_cus,
-                                           AieAqlQueue& aie_queue) {
+hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, AieAqlQueue& aie_queue) {
   const size_t config_cu_param_size =
-      sizeof(amdxdna_hwctx_param_config_cu) + new_cus.size() * sizeof(amdxdna_cu_config);
+      sizeof(amdxdna_hwctx_param_config_cu) + pdi_bo_handles.size() * sizeof(amdxdna_cu_config);
 
   auto* xdna_config_cu_param =
       static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
@@ -786,14 +789,14 @@ hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(const std::vector<BOHandle>& new_cus,
   }
   MAKE_SCOPE_GUARD([xdna_config_cu_param] { free(xdna_config_cu_param); });
 
-  xdna_config_cu_param->num_cus = new_cus.size();
+  xdna_config_cu_param->num_cus = pdi_bo_handles.size();
 
-  for (size_t i = 0; i < new_cus.size(); i++) {
-    xdna_config_cu_param->cu_configs[i].cu_bo = new_cus[i].handle;
+  for (size_t i = 0; i < pdi_bo_handles.size(); i++) {
+    xdna_config_cu_param->cu_configs[i].cu_bo = pdi_bo_handles[i].handle;
     xdna_config_cu_param->cu_configs[i].cu_func = DEFAULT_CU_FUNC;
 
     // Flush the CU out of the cache
-    FlushCpuCache(new_cus[i].vaddr, 0, new_cus[i].size);
+    FlushCpuCache(pdi_bo_handles[i].vaddr, 0, pdi_bo_handles[i].size);
   }
 
   if (aie_queue.GetHwCtxHandle() != AMDXDNA_INVALID_BO_HANDLE) {

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -474,8 +474,9 @@ hsa_status_t XdnaDriver::ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& bo_handles,
-                                        hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload) {
+hsa_status_t XdnaDriver::FindBOs(uint32_t count,
+                                 hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload,
+                                 std::vector<uint32_t>& bo_handles) {
   const uint64_t instr_addr =
       Concat<uint64_t>(cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX + 1],
                        cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX]);
@@ -589,7 +590,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
 
     // Add the handles for all of the BOs to bo_handles as well as rewrite
     // the command payload handles to contain the actual virtual addresses
-    hsa_status_t status = RegisterCmdBOs(pkt->count, bo_handles, cmd_pkt_payload);
+    hsa_status_t status = FindBOs(pkt->count, cmd_pkt_payload, bo_handles);
     if (status != HSA_STATUS_SUCCESS) {
       return status;
     }

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -455,17 +455,27 @@ hsa_status_t XdnaDriver::FreeDeviceHeap() {
   return status;
 }
 
-hsa_status_t XdnaDriver::ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t hw_ctx_handle) {
-  // Submit the cmd
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_EXEC_CMD, exec_cmd) < 0) {
+hsa_status_t XdnaDriver::ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
+                                        const std::vector<uint32_t>& bo_handles,
+                                        AieAqlQueue& aie_queue) {
+  // Submit command chain.
+  amdxdna_drm_exec_cmd exec_cmd = {};
+  exec_cmd.hwctx = aie_queue.GetHwCtxHandle();
+  exec_cmd.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
+  exec_cmd.cmd_handles = cmd_chain_bo_handle.handle;
+  exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
+  exec_cmd.cmd_count = 1;
+  exec_cmd.arg_count = bo_handles.size();
+
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
     return HSA_STATUS_ERROR;
   }
 
-  // Waiting for command to finish
+  // Waiting for command chain to finish.
   amdxdna_drm_wait_cmd wait_cmd = {};
-  wait_cmd.hwctx = hw_ctx_handle;
+  wait_cmd.hwctx = aie_queue.GetHwCtxHandle();
   wait_cmd.timeout = DEFAULT_TIMEOUT_VAL;
-  wait_cmd.seq = exec_cmd->seq;
+  wait_cmd.seq = exec_cmd.seq;
 
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
     return HSA_STATUS_ERROR;
@@ -560,7 +570,7 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
 }
 
 hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
-                                        uint32_t& hw_ctx_handle, uint32_t num_tiles) {
+                                        AieAqlQueue& aie_queue) {
   // Stores instruction and operand BOs.
   std::vector<uint32_t> bo_handles;
 
@@ -651,7 +661,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // If we have CUs that are not cached we will add them to
   // the hardware context
   if (!new_cus.empty()) {
-    hsa_status_t status = ConfigHwCtxNewCUs(hw_ctx_handle, new_cus, num_tiles);
+    hsa_status_t status = ConfigHwCtxNewCUs(new_cus, aie_queue);
     if (status != HSA_STATUS_SUCCESS) {
       return status;
     }
@@ -695,17 +705,11 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   std::sort(bo_handles.begin(), bo_handles.end());
   bo_handles.erase(std::unique(bo_handles.begin(), bo_handles.end()), bo_handles.end());
 
-  // Filling in the fields to execute the command chain
-  amdxdna_drm_exec_cmd exec_cmd_0 = {};
-  exec_cmd_0.hwctx = hw_ctx_handle;
-  exec_cmd_0.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
-  exec_cmd_0.cmd_handles = cmd_chain_bo_handle.handle;
-  exec_cmd_0.args = reinterpret_cast<uint64_t>(bo_handles.data());
-  exec_cmd_0.cmd_count = 1;
-  exec_cmd_0.arg_count = bo_handles.size();
-
   // Executing all commands in the command chain
-  ExecCmdAndWait(&exec_cmd_0, hw_ctx_handle);
+  status = ExecCmdAndWait(cmd_chain_bo_handle, bo_handles, aie_queue);
+  if (status != HSA_STATUS_SUCCESS) {
+    return status;
+  }
 
   for (uint32_t pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
     hsa_amd_aie_ert_packet_t* pkt = first_pkt + pkt_iter;
@@ -770,9 +774,8 @@ XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
 }
 
 // Creates a new hardware context with the correct CUs
-hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle,
-                                           const std::vector<BOHandle>& new_cus,
-                                           uint32_t num_tiles) {
+hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(const std::vector<BOHandle>& new_cus,
+                                           AieAqlQueue& aie_queue) {
   const size_t config_cu_param_size =
       sizeof(amdxdna_hwctx_param_config_cu) + new_cus.size() * sizeof(amdxdna_cu_config);
 
@@ -793,14 +796,14 @@ hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle,
     FlushCpuCache(new_cus[i].vaddr, 0, new_cus[i].size);
   }
 
-  if (hw_ctx_handle != AMDXDNA_INVALID_BO_HANDLE) {
+  if (aie_queue.GetHwCtxHandle() != AMDXDNA_INVALID_BO_HANDLE) {
     // Destroy the hardware context
     // Note: we can do this because we have forced synchronization between
     // command chains. If we move to a more asynchronous model, we will need to
     // figure out how hardware context destruction works while applications
     // are running
     amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
-    destroy_hwctx_args.handle = hw_ctx_handle;
+    destroy_hwctx_args.handle = aie_queue.GetHwCtxHandle();
     if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
       return HSA_STATUS_ERROR;
     }
@@ -812,17 +815,15 @@ hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle,
   amdxdna_drm_create_hwctx create_hwctx_args = {};
   create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
   create_hwctx_args.max_opc = 0x800;
-  create_hwctx_args.num_tiles = num_tiles;
+  create_hwctx_args.num_tiles = aie_queue.GetAgent().GetNumCores();
 
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  hw_ctx_handle = create_hwctx_args.handle;
-
   // Configure the new hardware context
   amdxdna_drm_config_hwctx config_hw_ctx_args = {};
-  config_hw_ctx_args.handle = hw_ctx_handle;
+  config_hw_ctx_args.handle = create_hwctx_args.handle;
   config_hw_ctx_args.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   config_hw_ctx_args.param_val = reinterpret_cast<uint64_t>(xdna_config_cu_param);
   config_hw_ctx_args.param_val_size = static_cast<uint32_t>(config_cu_param_size);
@@ -830,6 +831,8 @@ hsa_status_t XdnaDriver::ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle,
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args) < 0) {
     return HSA_STATUS_ERROR;
   }
+
+  aie_queue.SetHwCtxHandle(create_hwctx_args.handle);
 
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -53,8 +53,6 @@
 namespace rocr {
 namespace AMD {
 
-class XdnaDriver;
-
 /// @brief Encapsulates HW AIE AQL Command Processor functionality. It
 /// provides the interface for things such as doorbells, queue read and
 /// write pointers, and a buffer.
@@ -70,7 +68,6 @@ public:
     return queue->IsType(&rtti_id());
   }
 
-  AieAqlQueue() = delete;
   AieAqlQueue(AieAgent *agent, size_t req_size_pkts, uint32_t node_id);
   ~AieAqlQueue();
 
@@ -155,6 +152,7 @@ private:
     return rtti_id_;
   }
 
+  DISALLOW_COPY_AND_ASSIGN(AieAqlQueue);
 };
 
 } // namespace AMD

--- a/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -59,7 +59,7 @@ namespace AMD {
 class AieAqlQueue : public core::Queue,
                     private core::LocalSignal,
                     core::DoorbellSignal {
-public:
+ public:
   static __forceinline bool IsType(core::Signal *signal) {
     return signal->IsType(&rtti_id());
   }
@@ -98,13 +98,20 @@ public:
                        void *value) override;
 
   // AIE-specific API
-  AieAgent &GetAgent() { return agent_; }
+
+  /// @brief Returns the agent associated with this queue.
+  AieAgent& GetAgent() { return agent_; }
+
+  /// @brief Sets the hardware context.
   void SetHwCtxHandle(uint32_t hw_ctx_handle) {
     hw_ctx_handle_ = hw_ctx_handle;
   }
+
+  /// @brief Returns the hardware context.
   uint32_t GetHwCtxHandle() const { return hw_ctx_handle_; }
 
   // GPU-specific queue functions are unsupported.
+
   hsa_status_t GetCUMasking(uint32_t num_cu_mask_count,
                             uint32_t *cu_mask) override;
   hsa_status_t SetCUMasking(uint32_t num_cu_mask_count,
@@ -114,16 +121,17 @@ public:
                   hsa_fence_scope_t releaseFence = HSA_FENCE_SCOPE_NONE,
                   hsa_signal_t *signal = NULL) override;
 
+ private:
   HSA_QUEUEID queue_id_ = INVALID_QUEUEID;
   /// @brief ID of AIE device on which this queue has been mapped.
   uint32_t node_id_ = std::numeric_limits<uint32_t>::max();
   /// @brief Queue size in bytes.
   uint32_t queue_size_bytes_ = std::numeric_limits<uint32_t>::max();
 
-protected:
+ protected:
   bool _IsA(Queue::rtti_t id) const override { return id == &rtti_id(); }
 
-private:
+ private:
   AieAgent &agent_;
 
   /// @brief Base of the queue's ring buffer storage.

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -214,14 +214,13 @@ public:
   /// @param bo_info allocated BO
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info);
 
-  /// @brief Adds all BOs in a command packet payload to a vector
-  ///         and replaces the handles with a virtual address
+  /// @brief Finds all BOs in a command packet payload.
   ///
   /// @param count Number of entries in the command
-  /// @param bo_handles vector that contains all bo handles
   /// @param cmd_pkt_payload A pointer to the payload of the command
-  hsa_status_t RegisterCmdBOs(uint32_t count, std::vector<uint32_t>& bo_handles,
-                              hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload);
+  /// @param bo_handles vector that contains all BO handles
+  hsa_status_t FindBOs(uint32_t count, hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload,
+                       std::vector<uint32_t>& bo_handles);
 
   /// @brief Executes a command and waits for its completion
   ///

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -42,6 +42,8 @@
 #ifndef HSA_RUNTIME_CORE_INC_AMD_XDNA_DRIVER_H_
 #define HSA_RUNTIME_CORE_INC_AMD_XDNA_DRIVER_H_
 
+#include <array>
+#include <climits>
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -148,6 +150,48 @@ class XdnaDriver final : public core::Driver {
     constexpr bool IsValid() const { return handle != AMDXDNA_INVALID_BO_HANDLE; }
   };
 
+  /// @brief CU mask size.
+  static constexpr size_t cu_mask_size = sizeof(uint32_t) * CHAR_BIT;
+
+  /// @brief Per hardware context PDI cache.
+  class PDICache {
+    std::array<BOHandle, cu_mask_size> entries = {};
+    size_t entry_count = 0;
+
+   public:
+    /// @brief Sentinel value for entries not found.
+    constexpr static size_t NotFound = cu_mask_size;
+
+    /// @brief Returns the size of the cache.
+    constexpr size_t size() const { return entry_count; }
+
+    /// @brief Returns the index of the BO handle if it is the cache, otherwise @ref NotFound.
+    ///
+    /// This function does a linear search because the mask is small (32 elements).
+    size_t GetIndex(uint32_t pdi_handle) const {
+      for (size_t i = 0; i < entry_count; ++i) {
+        if (entries[i].handle == pdi_handle) {
+          return i;
+        }
+      }
+      return NotFound;
+    }
+
+    /// @brief Sets the next cache entry.
+    hsa_status_t SetNext(const BOHandle& pdi_bo_handle, size_t& index) {
+      if (entry_count == entries.size()) {
+        // cache is full
+        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      }
+
+      index = entry_count++;
+      entries[index] = pdi_bo_handle;
+      return HSA_STATUS_SUCCESS;
+    }
+
+    constexpr const BOHandle& operator[](size_t index) const { return entries[index]; }
+  };
+
 public:
   XdnaDriver(std::string devnode_name);
 
@@ -198,8 +242,8 @@ public:
   /// @brief Finds the BO associated with the address.
   BOHandle FindBOHandle(void* mem) const;
 
-  /// @brief Creates a new hardware context with the correct CUs
-  hsa_status_t ConfigHwCtxNewCUs(const std::vector<BOHandle>& new_cus, AieAqlQueue& aie_queue);
+  /// @brief Creates a new hardware context with the given PDI BO handles.
+  hsa_status_t ConfigHwCtx(const PDICache& pdi_bo_handles, AieAqlQueue& aie_queue);
 
   hsa_status_t QueryDriverVersion();
 
@@ -237,9 +281,8 @@ public:
   /// to manage some of this for now.
   std::map<void*, BOHandle> vmem_addr_mappings;
 
-  /// @brief Storing cached CUs that have already been added to the hardware context.
-  /// This maps the CU BO to the cu_mask in the hardware context
-  std::unordered_map<uint32_t, uint32_t> handle_cu_mappings;
+  /// @brief Hardware context to PDI cache mapping.
+  std::unordered_map<uint32_t, PDICache> hw_ctx_pdi_cache_map;
 
   /// @brief Virtual address range allocated for the device heap.
   ///
@@ -250,6 +293,7 @@ public:
 
   /// @brief The aligned device heap.
   void *dev_heap_aligned = nullptr;
+
   static constexpr size_t dev_heap_size = 64 * 1024 * 1024;
   static constexpr size_t dev_heap_align = 64 * 1024 * 1024;
 };

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -93,6 +93,8 @@ class Queue;
 
 namespace AMD {
 
+class AieAqlQueue;
+
 /// @brief: The number of arguments in the packet payload before we start passing operands
 constexpr uint32_t NON_OPERAND_COUNT = 6;
 
@@ -188,17 +190,16 @@ public:
                      size_t size) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
 
-  // @brief Submits num_pkts packets in a command chain to the XDNA driver
+  /// @brief Submits @p num_pkts packets in a command chain.
   hsa_status_t SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
-                              uint32_t& hw_ctx_handle, uint32_t num_tiles);
+                              AieAqlQueue& aie_queue);
 
  private:
   /// @brief Finds the BO associated with the address.
   BOHandle FindBOHandle(void* mem) const;
 
-  // @brief Creates a new hardware context with the correct CUs
-  hsa_status_t ConfigHwCtxNewCUs(uint32_t& hw_ctx_handle, const std::vector<BOHandle>& new_cus,
-                                 uint32_t num_tiles);
+  /// @brief Creates a new hardware context with the correct CUs
+  hsa_status_t ConfigHwCtxNewCUs(const std::vector<BOHandle>& new_cus, AieAqlQueue& aie_queue);
 
   hsa_status_t QueryDriverVersion();
 
@@ -224,10 +225,11 @@ public:
 
   /// @brief Executes a command and waits for its completion
   ///
-  /// @param exec_cmd Structure containing the details of the command to execute
-  /// @param hw_ctx_handle the handle of the hardware context to run this
-  /// command
-  hsa_status_t ExecCmdAndWait(amdxdna_drm_exec_cmd* exec_cmd, uint32_t hw_ctx_handle);
+  /// @param cmd_chain_bo_handle command to execute
+  /// @param bo_handles handles associated with the command
+  /// @param aie_queue queue to submit to
+  hsa_status_t ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
+                              const std::vector<uint32_t>& bo_handles, AieAqlQueue& aie_queue);
 
   /// TODO: Remove this in the future and rely on the core Runtime
   /// object to track handle allocations. Using the VMEM API for mapping XDNA

--- a/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -229,8 +229,7 @@ hsa_status_t AieAqlQueue::SubmitCmd(void* queue_base, uint64_t read_dispatch_id,
 
         // Call into the driver to submit from cur_id to write_dispatch_id.
         // Submitting the command chain might involve create a new hardware context.
-        hsa_status_t status = driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, hw_ctx_handle_,
-                                                    GetAgent().GetNumCores());
+        hsa_status_t status = driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, *this);
         if (status != HSA_STATUS_SUCCESS) {
           return status;
         }


### PR DESCRIPTION
This PR makes the PDI (CU) cache per hardware context. If the cache runs out of entries, it returns an error code to detect if we are out of entries. If we hit this limit, we need to come up with strategies on how to replace kernels (e.g., LRU etc.)